### PR TITLE
Add deploy.json to auto-build to ECR on PR and release

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -1,0 +1,4 @@
+{
+  "mojanalytics-deploy": "v0.1.0",
+  "type": "docker_build"
+}


### PR DESCRIPTION
Once https://github.com/ministryofjustice/analytics-platform-concourse-github-org-resource/pull/26 is merged this file will deploy this repo to ECR on PR and release.

All repos on this org prefixed with `docker-...` and this deploy file will build to ECR and can be used as base images.

This should that the test/build time to ~2min